### PR TITLE
feature: Capitalize first letter of link name

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -12,3 +12,7 @@ export function toArray<T>(v: T | T[] | null | undefined): T[] {
 	}
 	return [v];
 }
+
+export function capitalize(str: string): string {
+	return str.charAt(0).toUpperCase() + str.substring(1);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { addMissingAliasesIntoFile } from "./InjectAlias";
 import { Unregister } from "./ListenerRegistry";
 import { getReferenceCacheFromEditor, setLinkText } from "./MarkdownUtils";
 import { equalsPosition, isEditorPositionInPos, moveCursor, moveEditorPosition } from "./PositionUtils";
+import { capitalize } from "./Utils";
 import { getOrCreateFileOfLink } from "./VaultUtils";
 import { DEFAULT_SETTINGS, LinksSettingTab } from "./settings";
 
@@ -129,7 +130,7 @@ export default class LinkWithAliasPlugin extends Plugin {
 			//text is selected
 			if (options.pathFromText) {
 				// use it as link target and also link display text
-				editor.replaceSelection(`[[${selected_word}|${selected_word}]]`);
+				editor.replaceSelection(`[[${capitalize(selected_word)}|${selected_word}]]`);
 				linkStart = moveEditorPosition(moveCursor(editor, -(selected_word.length + 3)), -(selected_word.length + 2));
 				linkText = selected_word;
 			} else {

--- a/tests/TestUtils.ts
+++ b/tests/TestUtils.ts
@@ -1,0 +1,16 @@
+import { capitalize } from "../src/Utils";
+
+describe("", () => {
+	it("uppercase first letter from 3", () => {
+		expect(capitalize("abc")).toEqual("Abc");
+	});
+	it("Uppercase one letter", () => {
+		expect(capitalize("a")).toEqual("A");
+	});
+	it("Uppercase empty string", () => {
+		expect(capitalize("")).toEqual("");
+	});
+	it("Uppercase whitespace", () => {
+		expect(capitalize(" a")).toEqual(" a");
+	});
+});


### PR DESCRIPTION
Implements the requirement mentioned on 3.7.2023 by @Gourav1910 
The first letter of the copied display text is capitalized because most users are using capital letter at the beginning of their notes